### PR TITLE
Bump regex version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["Currency", "Money", "Monet"]
 license = "MPL-2.0"
 
 [dependencies]
-regex = { version = "0.1", optional = true }
+regex = { version = "1.0.0", optional = true }
 
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }


### PR DESCRIPTION
Hi!

I've been scraping crates.io for regex to use for testing the regex crate and I noticed that the regex that claude uses does not parse for the most recent version of the crate. I want to be able to test all the regex on crates.io if possible, so I looking into bumping the version of regex used by claude. In the process I also noticed a comment in your code asking for anyone looking at it to remove a loop around `captures_iter`, so I did!

This patch neither adds a feature nor fixes a bug, so sorry for the drive by PR.

Cheers!